### PR TITLE
Clarify ECS Exec cannot be used with read-only filesystem containers

### DIFF
--- a/doc_source/ecs-exec.md
+++ b/doc_source/ecs-exec.md
@@ -25,6 +25,7 @@ For this topic, you should be familiar with the following aspects involved with 
 + Users can run all of the commands that are available within the container context\. The following actions might result in orphaned and zombie processes: terminating the main process of the container, terminating the command agent, and deleting dependencies\. To cleanup zombie processes, we recommend adding the `initProcessEnabled` flag to your task definition\.
 + While starting SSM sessions outside of the `execute-command` action is possible, this results in the sessions not being logged and being counted against the session limit\. We recommend limiting this access by denying the `ssm:start-session` action using an IAM policy\. For more information, see [Limiting access to the Start Session action](#ecs-exec-limit-access-start-session)\.
 + ECS Exec will use some CPU and memory\. You'll want to accomodate for that when specifying the CPU and memory resource allocations in your task definition\.
++ The SSM agent requires the container filesystem is writable to create the required files and directories\. Therefore enabling the `readonlyRootFilesystem` option is not supported\.
 
 ## Prerequisites for using ECS Exec<a name="ecs-exec-prerequisites"></a>
 


### PR DESCRIPTION
The managed agents for ECS Exec (= SSM agents at this moment) require writable filesystems to create the required files and directories to work. Adding this note to the documentation would make troubleshooting easier for users.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
